### PR TITLE
fix: replace space with "%20" failed search.

### DIFF
--- a/newsapi/newsapi.go
+++ b/newsapi/newsapi.go
@@ -91,7 +91,7 @@ func (n *newsApi) SearchNews(query string) ([]*News, error) {
 	if query == "" {
 		return nil, ErrEmptyQuery
 	}
-	query = strings.ReplaceAll(query, " ", "%20")
+	// query = strings.ReplaceAll(query, " ", "%20")
 	return n.getNews("rss/search", query)
 }
 


### PR DESCRIPTION
Hi, I've found current API of `SearchNews(query)` doesn't work for queries with space.

- like: `azure ad persistence`, when runs with `api.SearchNews("azure ad persistence")` no results got. 

But if we search with Chrome manually, we can see there are lot's of results, and the url is `https://news.google.com/search?for=azure+ad+persistence&hl=en-US&gl=US&ceid=US%3Aen`

so I print out the URL and found 
`https://news.google.com/rss/search?ceid=US%3Aen&gl=US&hl=en&q=azure%2520ad%2520persistence`, 
and this should be caused by 
- first, we do strings.ReplaceAll
- then, we call `q.Encode()` in composeURL

